### PR TITLE
trigger alert for logs where message contains string 'EHOSTUNREACH'

### DIFF
--- a/openshift/fluent.conf
+++ b/openshift/fluent.conf
@@ -56,13 +56,12 @@
 
   <rule>
     key     log
-    # filter logs containing string 'EHOSTUNREACH'. for example: 'ERR! Error: connect EHOSTUNREACH 172.50.242.155:6379'
+    # filter logs containing string 'EHOSTUNREACH'. for example: 'ERR! Error: connect EHOSTUNREACH 127.0.0.1:6379'
     pattern EHOSTUNREACH
     tag     ${tag}.error
   </rule>
 
 </match>
-
 
 # reformat *.error logs into a Discord post
 # content ${record["product"]} - HTTP response status code ${record["code"]}, hostname: ${record["hostname"]}, namespace: ${record["namespace"]}, agent: ${record["agent"]}, method: ${record["method"]}, path: ${record["path"]}, log: ${record["log"]}
@@ -73,7 +72,7 @@
   auto_typecast true
   <record>
     username ${record["product"].upcase} (${record["namespace"]}) Alert
-    content ```json\r${record.to_json}\r```
+    content ```json\n${record.to_json}\n```
   </record>
 
 </filter>

--- a/openshift/fluent.conf
+++ b/openshift/fluent.conf
@@ -49,25 +49,36 @@
   capitalize_regex_backreference yes
   <rule>
     key     code
-    pattern ^4\d\d$
+    # filter for 5** HTTP response codes
+    pattern ^5\d\d$
     tag     ${tag}.error
   </rule>
+
+  <rule>
+    key     log
+    # filter logs containing string 'EHOSTUNREACH'. for example: 'ERR! Error: connect EHOSTUNREACH 172.50.242.155:6379'
+    pattern EHOSTUNREACH
+    tag     ${tag}.error
+  </rule>
+
 </match>
 
-# reformat dogs_node.error logs for output via notification
+
+# reformat *.error logs into a Discord post
+# content ${record["product"]} - HTTP response status code ${record["code"]}, hostname: ${record["hostname"]}, namespace: ${record["namespace"]}, agent: ${record["agent"]}, method: ${record["method"]}, path: ${record["path"]}, log: ${record["log"]}
 <filter app.error>
 
   @type record_transformer
-  # add a description of the error to a new key named 'content', and a 'username' required by Discord
-  enable_ruby
+  enable_ruby true
+  auto_typecast true
   <record>
-    content ${record["product"]} - HTTP response status code ${record["code"]}, hostname: ${record["hostname"]}, namespace: ${record["namespace"]}, agent: ${record["agent"]}, method: ${record["method"]}, path: ${record["path"]}
-    username ${record["product"].upcase} (${record["namespace"]}) Error Alert
+    username ${record["product"].upcase} (${record["namespace"]}) Alert
+    content ```json\r${record.to_json}\r```
   </record>
 
 </filter>
 
-## output CDOGS errors to Discord AND stdout
+## output errors to Discord AND stdout
 <match app.error>
   # You need to use the 'copy' output plugin to output the same log to multiple sources
   @type copy


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Fluentd should check incoming log messges and send alert if log contains string 'EHOSTUNREACH'
this happens when there's an issue where CHES container can't reach redis service.

I also changed the format of the message that is posted to Discord to make it a bit more readable.


## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
